### PR TITLE
Add collection-scoped full-text search

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -251,6 +251,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/by-reference?actType=...&year=...&number=...` | Fetch law by official reference |
 | `GET` | `/api/search?q=keyword&limit=10` | Search law metadata |
 | `GET` | `/api/fulltext-search?q=keyword&celex=32016R0679&limit=10` | Strict AND search inside English body text (articles and recitals), with snippets and highlight ranges |
+| `POST` | `/api/fulltext-search` with `{ "q": "keyword", "celexes": ["32016R0679"], "limit": 10 }` | Strict AND search inside a supplied CELEX collection |
 | `GET` | `/api/definitions/search?q=term&limit=10&filter=different` | Search extracted legal definitions; omit `q` and use `filter=different` or `filter=reused` for discovery |
 | `GET` | `/api/definitions/compare?term=risk` | Compare a term's definitions across laws |
 | `GET` | `/api/topics?celex=32016R0679,32024R1689` | Bulk EuroVoc topics for up to 200 CELEX ids (`{ topics: { CELEX: string[] } }`) |
@@ -261,12 +262,15 @@ cat input.xml | parse-fmx > output.json
 `/api/search` searches a local metadata cache of primary regulations/directives/decisions.
 `/api/fulltext-search` searches the optional English full-text index's `text`
 column only. It accepts `q` (required, at most 200 characters and 12
-searchable terms, with at least one term of 2+ characters), an optional CELEX scope, and `limit` (1–50); there is no
-offset in this first version. Unquoted terms are prefix-matched and quoted
-segments are phrase-matched. Queries use strict AND semantics and punctuation-
-only input is rejected. Global results return at most one best unit per CELEX;
-CELEX-scoped results may include multiple matching units from that act. Each
-result contains `{ celex, title, unitType, number, heading, snippet,
+searchable terms, with at least one term of 2+ characters), an optional CELEX
+scope, and `limit` (1–50); there is no offset in this first version. Unquoted
+terms are prefix-matched and quoted segments are phrase-matched. Queries use
+strict AND semantics and punctuation-only input is rejected. Global results
+return at most one best unit per CELEX; GET requests scoped to one CELEX may
+include multiple matching units from that act. POST requests take
+`{ q, celexes, limit }`, require 1–200 valid CELEX values, and return one best
+unit per requested CELEX after normalising and deduplicating the collection.
+Each result contains `{ celex, title, unitType, number, heading, snippet,
 highlightRanges }`; the snippet is plain text and ranges use zero-based
 `{start, end}` offsets. If the optional artifact is missing or stale, the
 endpoint returns `503` with `code=fulltext_index_unavailable` and the

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -874,6 +874,7 @@ function registerApiRoutes(app, deps) {
   app.get('/api/search', rateLimitMiddleware, createSearchHandler(legalCacheStore));
 
   app.get('/api/fulltext-search', rateLimitMiddleware, createFulltextSearchHandler(legalCacheStore, { validateCelex }));
+  app.post('/api/fulltext-search', rateLimitMiddleware, createFulltextSearchHandler(legalCacheStore, { validateCelex, collection: true }));
 
   app.get('/api/definitions/search', rateLimitMiddleware, createDefinitionSearchHandler(legalCacheStore));
 
@@ -964,6 +965,7 @@ function registerApiRoutes(app, deps) {
         'GET /api/laws/:celex/articles/:n/case-law-digest?lang=ENG': 'Get cached static digest of CJEU case law interpreting one article',
         'GET /api/search?q=keyword&limit=10': 'Search cached primary-law metadata',
         'GET /api/fulltext-search?q=keyword&celex=32016R0679&limit=10': 'Search body text of cached law units (articles and recitals)',
+        'POST /api/fulltext-search': 'Search body text within a supplied CELEX collection',
         'GET /api/definitions/search?q=term&limit=10': 'Search definitions extracted from EU laws',
         'GET /api/definitions/compare?term=energy%20poverty': 'Compare how EU laws define a term',
         'GET /api/resolve-reference?actType=directive&year=2018&number=1972&lang=ENG': 'Resolve an FMX-derived legal reference to CELEX via cache-first lookup with Cellar fallback',

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -21,13 +21,17 @@ const gdprFmxPath = path.join(__dirname, "..", "..", "src", "__fixtures__", "gdp
 
 function createAppRecorder() {
   const routes = new Map();
+  const middleware = new Map();
   return {
     routes,
+    middleware,
     get(routePath, ...handlers) {
       routes.set(routePath, handlers[handlers.length - 1]);
+      middleware.set(routePath, handlers.slice(0, -1));
     },
     post(routePath, ...handlers) {
       routes.set(`POST ${routePath}`, handlers[handlers.length - 1]);
+      middleware.set(`POST ${routePath}`, handlers.slice(0, -1));
     },
   };
 }
@@ -1236,6 +1240,37 @@ test("GET /api/fulltext-search is registered with rate limiting and delegates bo
   assert.equal(res.payload.count, 1);
   assert.equal(res.payload.celex, "32016R0679");
   assert.deepEqual(calls, [{ query: "data", options: { limit: "1", celex: "32016R0679" } }]);
+});
+
+test("POST /api/fulltext-search is registered with the shared rate limiter and delegates collection search", () => {
+  const calls = [];
+  const rateLimitMiddleware = () => {};
+  const { app } = registerTestRoutes({
+    rateLimitMiddleware,
+    legalCacheStore: {
+      searchFulltextUnits: (query, options) => {
+        calls.push({ query, options });
+        return [{ celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] }];
+      },
+      getFulltextStatus: () => ({ available: true }),
+    },
+    validateCelex: (value) => ["32016R0679", "32024R1689"].includes(value),
+  });
+  const routeKey = "POST /api/fulltext-search";
+  const handler = app.routes.get(routeKey);
+  const res = createResponseRecorder();
+
+  assert.equal(typeof handler, "function");
+  assert.deepEqual(app.middleware.get(routeKey), [rateLimitMiddleware]);
+  handler({ method: "POST", body: { q: " data ", celexes: ["32016r0679", "32024R1689", "32016R0679"], limit: 2 } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload.celexes, ["32016R0679", "32024R1689"]);
+  assert.equal(res.payload.count, 1);
+  assert.deepEqual(calls, [{
+    query: "data",
+    options: { limit: 2, celexes: ["32016R0679", "32024R1689"] },
+  }]);
 });
 
 test("GET /api/laws/:celex/info reports Formex availability", async () => {

--- a/backend/search/fulltext-route.js
+++ b/backend/search/fulltext-route.js
@@ -6,10 +6,52 @@ const {
   isFulltextQueryError,
 } = require("./fulltext-errors");
 
-function createFulltextSearchHandler(store, { validateCelex } = {}) {
+const FULLTEXT_COLLECTION_MAX_CELEXES = 200;
+
+function fulltextCelexesRequiredError() {
+  return {
+    error: 'Request body property "celexes" must be a non-empty array',
+    code: "fulltext_celexes_required",
+  };
+}
+
+function normalizeCollectionCelexes(value, validateCelex) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return { error: fulltextCelexesRequiredError() };
+  }
+  if (value.length > FULLTEXT_COLLECTION_MAX_CELEXES) {
+    return {
+      error: {
+        error: `Request body property "celexes" may contain at most ${FULLTEXT_COLLECTION_MAX_CELEXES} CELEX values`,
+        code: "fulltext_celexes_too_many",
+      },
+    };
+  }
+
+  const normalized = [];
+  const seen = new Set();
+  for (const valueItem of value) {
+    if (typeof valueItem !== "string") {
+      return { error: { error: "Invalid CELEX format", code: "invalid_celex" } };
+    }
+    const celex = valueItem.trim().toUpperCase();
+    if (!celex || (typeof validateCelex === "function" && !validateCelex(celex))) {
+      return { error: { error: "Invalid CELEX format", code: "invalid_celex" } };
+    }
+    if (!seen.has(celex)) {
+      seen.add(celex);
+      normalized.push(celex);
+    }
+  }
+  return { celexes: normalized };
+}
+
+function createFulltextSearchHandler(store, { validateCelex, collection = false } = {}) {
   return function fulltextSearchHandler(req, res) {
     try {
-      const query = String(req.query.q || "").trim();
+      const isCollectionSearch = collection || req.method === "POST";
+      const input = isCollectionSearch ? (req.body || {}) : (req.query || {});
+      const query = String(input.q || "").trim();
       if (!query) {
         return res.status(400).json({
           error: 'Query parameter "q" required',
@@ -21,16 +63,32 @@ function createFulltextSearchHandler(store, { validateCelex } = {}) {
         return res.status(400).json({ error: queryError.message, code: queryError.code });
       }
 
+      if (isCollectionSearch) {
+        const normalized = normalizeCollectionCelexes(input.celexes, validateCelex);
+        if (normalized.error) return res.status(400).json(normalized.error);
+
+        const results = store.searchFulltextUnits(query, {
+          limit: input.limit,
+          celexes: normalized.celexes,
+        });
+        return res.json({
+          query,
+          celexes: normalized.celexes,
+          count: results.length,
+          results,
+        });
+      }
+
       let celex = null;
-      if (req.query.celex !== undefined && req.query.celex !== null && String(req.query.celex).trim()) {
-        celex = String(req.query.celex).trim().toUpperCase();
+      if (input.celex !== undefined && input.celex !== null && String(input.celex).trim()) {
+        celex = String(input.celex).trim().toUpperCase();
         if (typeof validateCelex === "function" && !validateCelex(celex)) {
           return res.status(400).json({ error: "Invalid CELEX format", code: "invalid_celex" });
         }
       }
 
       const results = store.searchFulltextUnits(query, {
-        limit: req.query.limit,
+        limit: input.limit,
         celex,
       });
       return res.json({ query, celex, count: results.length, results });

--- a/backend/search/fulltext-route.test.js
+++ b/backend/search/fulltext-route.test.js
@@ -61,7 +61,10 @@ test("fulltext POST route normalizes and deduplicates a CELEX collection", () =>
 test("fulltext POST route rejects malformed collections with stable codes", () => {
   const handler = createFulltextSearchHandler({
     searchFulltextUnits() { throw new Error("must not search invalid input"); },
-  }, { validateCelex: () => true, collection: true });
+  }, {
+    validateCelex: (value) => /^\d{5}[A-Z]{1,2}\d{4}(?:\([0-9]+\))?$/.test(value),
+    collection: true,
+  });
 
   for (const celexes of [undefined, null, "32016R0679", []]) {
     const res = response();

--- a/backend/search/fulltext-route.test.js
+++ b/backend/search/fulltext-route.test.js
@@ -31,6 +31,58 @@ test("fulltext route returns normalized scoped results and forwards the bounded 
   assert.deepEqual(calls, [{ query: "data", options: { limit: "50", celex: "32016R0679" } }]);
 });
 
+test("fulltext POST route normalizes and deduplicates a CELEX collection", () => {
+  const calls = [];
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits(query, options) {
+      calls.push({ query, options });
+      return [{ celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] }];
+    },
+  }, {
+    validateCelex: (value) => ["32016R0679", "32024R1689"].includes(value),
+    collection: true,
+  });
+  const res = response();
+
+  handler({
+    method: "POST",
+    body: { q: "  data  ", celexes: [" 32016r0679 ", "32024r1689", "32016R0679"], limit: 50 },
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload.celexes, ["32016R0679", "32024R1689"]);
+  assert.equal(res.payload.count, 1);
+  assert.deepEqual(calls, [{
+    query: "data",
+    options: { limit: 50, celexes: ["32016R0679", "32024R1689"] },
+  }]);
+});
+
+test("fulltext POST route rejects malformed collections with stable codes", () => {
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits() { throw new Error("must not search invalid input"); },
+  }, { validateCelex: () => true, collection: true });
+
+  for (const celexes of [undefined, null, "32016R0679", []]) {
+    const res = response();
+    handler({ method: "POST", body: { q: "data", celexes } }, res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.payload.code, "fulltext_celexes_required");
+  }
+
+  const tooMany = response();
+  handler({ method: "POST", body: { q: "data", celexes: Array.from({ length: 201 }, () => "32016R0679") } }, tooMany);
+  assert.equal(tooMany.statusCode, 400);
+  assert.equal(tooMany.payload.code, "fulltext_celexes_too_many");
+
+  for (const celexes of [["not-a-celex"], [null], ["  "]]) {
+    const res = response();
+    handler({ method: "POST", body: { q: "data", celexes } }, res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.payload.code, "invalid_celex");
+  }
+});
+
 test("fulltext route validates required, bounded, punctuation-only, and CELEX input", () => {
   const handler = createFulltextSearchHandler({
     searchFulltextUnits() { throw new Error("must not search invalid input"); },

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -591,6 +591,7 @@ class JsonLegalCacheStore {
     this.fulltextSearchStatement = null;
     this.fulltextUnitSearchStatement = null;
     this.fulltextUnitScopedSearchStatement = null;
+    this.fulltextUnitCollectionSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
@@ -619,6 +620,7 @@ class JsonLegalCacheStore {
     this.fulltextSearchStatement = null;
     this.fulltextUnitSearchStatement = null;
     this.fulltextUnitScopedSearchStatement = null;
+    this.fulltextUnitCollectionSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
@@ -684,6 +686,18 @@ class JsonLegalCacheStore {
         ORDER BY rank, u.id
         LIMIT ${FULLTEXT_UNIT_CANDIDATE_CAP}
       `);
+      this.fulltextUnitCollectionSearchStatement = database.prepare(`
+        SELECT u.id AS id, u.celex AS celex, u.unit_type AS unitType,
+               u.number AS number, u.heading AS heading,
+               MIN(units_fts.rank) AS bestRank
+        FROM units_fts
+        JOIN units u ON u.id = units_fts.rowid
+        JOIN json_each(?) AS requested ON requested.value = u.celex
+        WHERE units_fts.text MATCH ?
+        GROUP BY u.celex
+        ORDER BY bestRank, u.id
+        LIMIT ${FULLTEXT_UNIT_CANDIDATE_CAP}
+      `);
       // Computing snippet() for the whole candidate window makes common-prefix
       // queries needlessly expensive. Rank/diversify first, then render only
       // the handful of units that cross the API boundary.
@@ -709,6 +723,7 @@ class JsonLegalCacheStore {
       this.fulltextSearchStatement = null;
       this.fulltextUnitSearchStatement = null;
       this.fulltextUnitScopedSearchStatement = null;
+      this.fulltextUnitCollectionSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
       this.fulltextAvailable = false;
       this.fulltextReason = error.message;
@@ -761,15 +776,39 @@ class JsonLegalCacheStore {
 
     const rawLimit = Number.parseInt(options.limit, 10);
     const limit = Math.max(1, Math.min(Number.isFinite(rawLimit) ? rawLimit : 10, FULLTEXT_RESULT_LIMIT));
-    const celex = options.celex ? normalizeCelexLookupKey(options.celex) : null;
-    const rows = celex
-      ? this.fulltextUnitScopedSearchStatement.all(expression, celex)
-      : this.fulltextUnitSearchStatement.all(expression);
+    const hasCelex = options.celex !== undefined && options.celex !== null && String(options.celex).trim() !== "";
+    const hasCelexes = Object.prototype.hasOwnProperty.call(options, "celexes")
+      && options.celexes !== undefined
+      && options.celexes !== null;
+    if (hasCelex && hasCelexes) {
+      const error = new Error('Specify either "celex" or "celexes", not both');
+      error.code = "fulltext_scope_ambiguous";
+      throw error;
+    }
+
+    const celex = hasCelex ? normalizeCelexLookupKey(options.celex) : null;
+    let rows;
+    if (hasCelexes) {
+      if (!Array.isArray(options.celexes)) {
+        const error = new Error('"celexes" must be an array');
+        error.code = "fulltext_celexes_required";
+        throw error;
+      }
+      const celexes = [...new Set(options.celexes.map(normalizeCelexLookupKey).filter(Boolean))];
+      rows = celexes.length === 0
+        ? []
+        : this.fulltextUnitCollectionSearchStatement.all(JSON.stringify(celexes), expression);
+    } else {
+      rows = celex
+        ? this.fulltextUnitScopedSearchStatement.all(expression, celex)
+        : this.fulltextUnitSearchStatement.all(expression);
+    }
     const seen = new Set();
     const selected = [];
     for (const row of rows) {
-      // Global discovery returns at most one best unit per act. A scoped query
-      // intentionally keeps multiple provisions from the requested act.
+      // Global and collection searches return one best unit per act. A
+      // single-CELEX query intentionally keeps multiple provisions from that
+      // requested act.
       if (!celex && seen.has(row.celex)) continue;
       seen.add(row.celex);
       selected.push(row);
@@ -1633,6 +1672,7 @@ class JsonLegalCacheStore {
       this.fulltextSearchStatement = null;
       this.fulltextUnitSearchStatement = null;
       this.fulltextUnitScopedSearchStatement = null;
+      this.fulltextUnitCollectionSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
       this.fulltextAvailable = false;
       this.fulltextReason = "Full-text index is closed";

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -1062,6 +1062,72 @@ test("global fulltext diversification happens before the bounded result window",
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
+test("collection fulltext search filters in SQLite before ranking and returns one unit per CELEX", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-collection-"));
+  const fulltextPath = path.join(tempDir, "fulltext.sqlite");
+  const crowdedCelex = "32022R0868";
+  const requestedCelex = "32024R1689";
+  const otherRequestedCelex = "32016R0679";
+  buildTestFulltextDb(fulltextPath, {
+    [crowdedCelex]: Array.from({ length: 500 }, (_, index) => ({
+      unit_type: "article",
+      number: String(index + 1),
+      text: "collectionprobe common wording.",
+    })),
+    [requestedCelex]: [
+      { unit_type: "article", number: "1", text: "collectionprobe requested wording." },
+      { unit_type: "article", number: "2", text: "collectionprobe requested wording continues." },
+    ],
+    [otherRequestedCelex]: [
+      { unit_type: "recital", number: "4", text: "collectionprobe other requested wording." },
+    ],
+  });
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath });
+  assert.equal(store.load(), true);
+
+  const results = store.searchFulltextUnits("collectionprobe", {
+    limit: 50,
+    celexes: [requestedCelex, requestedCelex.toLowerCase(), otherRequestedCelex],
+  });
+  assert.deepEqual(new Set(results.map((result) => result.celex)), new Set([requestedCelex, otherRequestedCelex]));
+  assert.equal(results.length, 2);
+  assert.equal(new Set(results.map((result) => result.celex)).size, results.length);
+  assert.equal(store.searchFulltextUnits("collectionprobe", { limit: 1, celexes: [requestedCelex, otherRequestedCelex] }).length, 1);
+  assert.throws(
+    () => store.searchFulltextUnits("collectionprobe", { celex: requestedCelex, celexes: [otherRequestedCelex] }),
+    (error) => error.code === "fulltext_scope_ambiguous",
+  );
+
+  store.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("collection fulltext search ranks only the requested CELEX values", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-collection-ranking-"));
+  const fulltextPath = path.join(tempDir, "fulltext.sqlite");
+  const strongerCelex = "32024R1689";
+  const weakerCelex = "32016R0679";
+  buildTestFulltextDb(fulltextPath, {
+    [weakerCelex]: [
+      { unit_type: "article", number: "1", text: "collectionrankingprobe." },
+    ],
+    [strongerCelex]: [
+      { unit_type: "article", number: "1", text: `${"collectionrankingprobe ".repeat(20)}.` },
+    ],
+  });
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath });
+  assert.equal(store.load(), true);
+
+  const results = store.searchFulltextUnits("collectionrankingprobe", {
+    limit: 50,
+    celexes: [weakerCelex, strongerCelex],
+  });
+  assert.deepEqual(results.map((result) => result.celex), [strongerCelex, weakerCelex]);
+
+  store.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
 test("searchFulltextUnits reports an unavailable artifact with a stable code", () => {
   const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath: path.join(os.tmpdir(), `missing-fulltext-${Date.now()}.sqlite`) });
   assert.equal(store.load(), true);

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -141,7 +141,6 @@ export function Landing({ forcedLocale = null }) {
           className="mt-10 flex flex-col items-center gap-2 text-center text-xs text-gray-500"
         >
           <p>{t("landing.builtBy")}</p>
-          <p>© Konrad Kollnig (Maastricht University)</p>
           <a
             href="https://github.com/maastrichtlawtech/eur-lex-visualiser"
             target="_blank"

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -141,6 +141,7 @@ export function Landing({ forcedLocale = null }) {
           className="mt-10 flex flex-col items-center gap-2 text-center text-xs text-gray-500"
         >
           <p>{t("landing.builtBy")}</p>
+          <p>© Konrad Kollnig (Maastricht University)</p>
           <a
             href="https://github.com/maastrichtlawtech/eur-lex-visualiser"
             target="_blank"


### PR DESCRIPTION
## Summary

- add `POST /api/fulltext-search` with `{ q, celexes, limit }`
- validate and normalise collections of 1–200 CELEX identifiers
- scope SQLite full-text ranking before limiting results
- preserve the existing GET endpoint unchanged

## Verification

- `git diff --check`
- `node --check` on all changed JavaScript files
- full Node tests deferred to CI because this checkout has no installed `better-sqlite3` dependency
