### PR TITLE
Expose cached law summaries without generation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -246,6 +246,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/:celex/case-law?lang=ENG` | CJEU judgments citing this act, with operative parts and structured `articleRefs` |
 | `GET` | `/api/laws/:celex/recital-titles?lang=ENG` | Cached AI-generated short titles for recitals. Requires `RECITAL_TITLE_OPENROUTER_API_KEY` or `OPENROUTER_API_KEY` on cache miss. |
 | `GET` | `/api/laws/:celex/summary?lang=ENG` | Cached static law overview with article citations. Requires `LAW_SUMMARY_OPENROUTER_API_KEY`, `ARTICLE_QA_OPENROUTER_API_KEY`, or `OPENROUTER_API_KEY` on cache miss. |
+| `GET` | `/api/laws/:celex/summary-cached` | Read-only English summary cache lookup. Never generates, resolves, or parses a law; returns `404 summary_not_cached` when no current model/version-matching entry exists. |
 | `GET` | `/api/laws/:celex/case-law-digest?lang=ENG` | Cached static digest of CJEU case law interpreting the whole act, grouped into doctrinal themes. Zero-case results are cached without an LLM call. |
 | `GET` | `/api/laws/:celex/articles/:n/case-law-digest?lang=ENG` | Cached static digest of CJEU case law interpreting one article. Zero-case results are cached without an LLM call. |
 | `GET` | `/api/laws/by-reference?actType=...&year=...&number=...` | Fetch law by official reference |
@@ -382,6 +383,12 @@ The backend stores titles in `recital-title-cache-v1.json` with a cache `version
   }
 }
 ```
+
+`GET /api/laws/:celex/summary-cached` is the read-only cache-only variant. It
+returns the same version fields and summary payload when a current English
+entry for the configured summary model exists, or `404` with
+`{ "error": "No cached summary is available", "code": "summary_not_cached" }`.
+It does not require an OpenRouter key.
 
 `GET /api/laws/:celex/articles/:n/case-law-digest?lang=ENG` returns a cached article-level digest:
 

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -27,6 +27,7 @@ const {
   PROMPT_VERSION: LAW_SUMMARY_PROMPT_VERSION,
   SCHEMA_VERSION: LAW_SUMMARY_SCHEMA_VERSION,
   ensureLawSummary,
+  getCachedLawSummary,
 } = require("../shared/law-summary-service");
 const { ensureArticleDigest } = require("../shared/article-digest-service");
 const { ensureCaseLawDigest } = require("../shared/case-law-digest-service");
@@ -224,6 +225,7 @@ function registerApiRoutes(app, deps) {
     resolveEurlexUrl,
     resolveParsedLaw,
     ensureLawSummary: ensureLawSummaryImpl = ensureLawSummary,
+    getCachedLawSummary: getCachedLawSummaryImpl = getCachedLawSummary,
     resolveReference,
     runSparqlQuery,
     safeErrorResponse,
@@ -758,6 +760,42 @@ function registerApiRoutes(app, deps) {
     }
   });
 
+  app.get('/api/laws/:celex/summary-cached', rateLimitMiddleware, async (req, res) => {
+    try {
+      const { celex } = req.params;
+
+      if (!validateCelex(celex)) {
+        return rejectInvalidCelex(res);
+      }
+
+      const lang = 'ENG';
+      const result = await getCachedLawSummaryImpl({
+        celex,
+        lang,
+        cacheDir: FMX_DIR,
+        model: DEFAULT_STATIC_SUMMARY_MODEL,
+      });
+
+      if (!result) {
+        return res.status(404).json({ error: 'No cached summary is available', code: 'summary_not_cached' });
+      }
+
+      res.json({
+        celex,
+        lang,
+        cacheVersion: LAW_SUMMARY_CACHE_VERSION,
+        schemaVersion: LAW_SUMMARY_SCHEMA_VERSION,
+        promptVersion: LAW_SUMMARY_PROMPT_VERSION,
+        model: result.model,
+        cached: result.cached,
+        generatedAt: result.generatedAt,
+        summary: result.summary,
+      });
+    } catch (err) {
+      safeErrorResponse(res, err, 'Failed to fetch cached law summary');
+    }
+  });
+
   app.get('/api/laws/:celex/articles/:n/case-law-digest', rateLimitMiddleware, generationOriginMiddleware, generationLimitMiddleware, async (req, res) => {
     try {
       const { celex } = req.params;
@@ -961,6 +999,7 @@ function registerApiRoutes(app, deps) {
         'GET /api/laws/:celex/articles/:n/cited-by?limit=50&offset=0': 'List provisions and judgments citing an article',
         'GET /api/laws/:celex/recital-titles?lang=ENG': 'Get cached AI-generated short titles for recitals',
         'GET /api/laws/:celex/summary': 'Get cached static summary of what this law does (English only)',
+        'GET /api/laws/:celex/summary-cached': 'Get a cached static summary without generation (English only)',
         'GET /api/laws/:celex/case-law-digest?lang=ENG': 'Get cached static digest of CJEU case law interpreting this law as a whole',
         'GET /api/laws/:celex/articles/:n/case-law-digest?lang=ENG': 'Get cached static digest of CJEU case law interpreting one article',
         'GET /api/search?q=keyword&limit=10': 'Search cached primary-law metadata',

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -901,6 +901,103 @@ test("GET /api/laws/:celex/summary returns the cache version contract", async ()
   });
 });
 
+test("GET /api/laws/:celex/summary-cached returns the versioned cache contract without an API key", async () => {
+  await withOpenRouterEnv({}, async () => {
+    const rateLimitMiddleware = () => {};
+    const generationOriginMiddleware = () => { throw new Error("generation origin middleware should not run"); };
+    const generationLimitMiddleware = () => { throw new Error("generation limit middleware should not run"); };
+    const calls = [];
+    const { app } = registerTestRoutes({
+      rateLimitMiddleware,
+      generationOriginMiddleware,
+      generationLimitMiddleware,
+      getCachedLawSummary: async (args) => {
+        calls.push(args);
+        return {
+          model: "test-model",
+          cached: true,
+          generatedAt: "2026-07-16T00:00:00.000Z",
+          summary: { purpose: { text: "Test", citations: [] } },
+        };
+      },
+      resolveParsedLaw: async () => {
+        throw new Error("summary-cached must not resolve or parse a law");
+      },
+    });
+    const routePath = "/api/laws/:celex/summary-cached";
+    const handler = app.routes.get(routePath);
+    const res = createResponseRecorder();
+
+    assert.deepEqual(app.middleware.get(routePath), [rateLimitMiddleware]);
+    await handler({
+      params: { celex: "32016R0679" },
+      query: { lang: "FRA" },
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.payload, {
+      celex: "32016R0679",
+      lang: "ENG",
+      cacheVersion: LAW_SUMMARY_CACHE_VERSION,
+      schemaVersion: LAW_SUMMARY_SCHEMA_VERSION,
+      promptVersion: LAW_SUMMARY_PROMPT_VERSION,
+      model: "test-model",
+      cached: true,
+      generatedAt: "2026-07-16T00:00:00.000Z",
+      summary: { purpose: { text: "Test", citations: [] } },
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].celex, "32016R0679");
+    assert.equal(calls[0].cacheDir, path.join(__dirname, "..", "fmx-downloads"));
+    assert.equal(typeof calls[0].model, "string");
+  });
+});
+
+test("GET /api/laws/:celex/summary-cached returns a stable 404 on a cache miss", async () => {
+  await withOpenRouterEnv({}, async () => {
+    let calls = 0;
+    const { app } = registerTestRoutes({
+      getCachedLawSummary: async () => {
+        calls += 1;
+        return null;
+      },
+      resolveParsedLaw: async () => {
+        throw new Error("summary-cached must not resolve or parse a law");
+      },
+    });
+    const handler = app.routes.get("/api/laws/:celex/summary-cached");
+    const res = createResponseRecorder();
+
+    await handler({ params: { celex: "32016R0679" }, query: {} }, res);
+
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(res.payload, {
+      error: "No cached summary is available",
+      code: "summary_not_cached",
+    });
+    assert.equal(calls, 1);
+  });
+});
+
+test("GET /api/laws/:celex/summary-cached rejects invalid CELEX before reading the cache", async () => {
+  let calls = 0;
+  const { app } = registerTestRoutes({
+    validateCelex: () => false,
+    getCachedLawSummary: async () => {
+      calls += 1;
+      return null;
+    },
+  });
+  const handler = app.routes.get("/api/laws/:celex/summary-cached");
+  const res = createResponseRecorder();
+
+  await handler({ params: { celex: "not-a-celex" }, query: {} }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.payload, { error: "Invalid CELEX format", code: "invalid_celex" });
+  assert.equal(calls, 0);
+});
+
 // These two tests exercise the *real* getSource/getParsedLaw closures wired
 // up inside the /api/laws/:celex/summary handler (unlike the "cache miss"
 // test above, which always passes skipFmxProbe=1 and therefore never calls

--- a/backend/shared/law-summary-service.js
+++ b/backend/shared/law-summary-service.js
@@ -113,6 +113,23 @@ function cachedResult(entry) {
   };
 }
 
+/**
+ * Return a current cached summary without resolving or parsing the law.
+ *
+ * This read-only path intentionally validates only the versioned cache entry
+ * and requested model: it must never migrate or otherwise write cache state.
+ * Static summaries are currently English-only, so use the existing CELEX+ENG
+ * cache key regardless of any caller language state.
+ */
+function getCachedLawSummary({ celex, cacheDir, model } = {}) {
+  if (!cacheDir) return null;
+
+  const key = celexLangKey(celex, 'ENG');
+  const cache = loadCache(cacheDir, CACHE_FILE);
+  const entry = cache[key];
+  return isServableEntry(entry, model) ? cachedResult(entry) : null;
+}
+
 function buildSkeleton(articles) {
   return (articles || []).map((article) => ({
     number: String(article.article_number || '').trim(),
@@ -361,6 +378,7 @@ module.exports = {
   SCHEMA_VERSION,
   buildLawSummaryInput,
   ensureLawSummary,
+  getCachedLawSummary,
   generateLawSummary,
   parseLawSummaryJson,
   rawSourceHash,

--- a/backend/shared/law-summary-service.test.js
+++ b/backend/shared/law-summary-service.test.js
@@ -7,7 +7,11 @@ const path = require('node:path');
 const {
   buildLawSummaryInput,
   ensureLawSummary,
+  getCachedLawSummary,
   parseLawSummaryJson,
+  CACHE_VERSION,
+  SCHEMA_VERSION,
+  PROMPT_VERSION,
 } = require('./law-summary-service');
 
 function sampleParsedLaw() {
@@ -34,6 +38,61 @@ function sampleParsedLaw() {
     definitions: [{ term: 'personal data', sourceArticle: '4' }],
   };
 }
+
+function writeSummaryCache(cacheDir, entry) {
+  fs.writeFileSync(path.join(cacheDir, 'law-summary-cache-v1.json'), JSON.stringify({
+    '32016R0679_ENG': entry,
+  }), 'utf8');
+}
+
+function validCachedSummaryEntry(overrides = {}) {
+  return {
+    version: CACHE_VERSION,
+    schemaVersion: SCHEMA_VERSION,
+    promptVersion: PROMPT_VERSION,
+    model: 'test-model',
+    generatedAt: '2026-07-16T00:00:00.000Z',
+    summary: { purpose: { text: 'Test', citations: [] } },
+    ...overrides,
+  };
+}
+
+test('getCachedLawSummary serves a current English summary without changing the cache', () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'law-summary-cache-read-'));
+  const entry = validCachedSummaryEntry();
+  writeSummaryCache(cacheDir, entry);
+  const before = fs.readFileSync(path.join(cacheDir, 'law-summary-cache-v1.json'), 'utf8');
+
+  assert.deepEqual(getCachedLawSummary({
+    celex: '32016r0679',
+    cacheDir,
+    model: 'test-model',
+  }), {
+    summary: entry.summary,
+    model: 'test-model',
+    generatedAt: entry.generatedAt,
+    cached: true,
+  });
+  assert.equal(fs.readFileSync(path.join(cacheDir, 'law-summary-cache-v1.json'), 'utf8'), before);
+});
+
+test('getCachedLawSummary returns null for an invalid cache version or requested model', () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'law-summary-cache-read-'));
+
+  for (const field of ['version', 'schemaVersion', 'promptVersion']) {
+    writeSummaryCache(cacheDir, validCachedSummaryEntry({ [field]: 'stale-version' }));
+    assert.equal(getCachedLawSummary({ celex: '32016R0679', cacheDir, model: 'test-model' }), null);
+  }
+
+  writeSummaryCache(cacheDir, validCachedSummaryEntry({ model: 'other-model' }));
+  assert.equal(getCachedLawSummary({ celex: '32016R0679', cacheDir, model: 'test-model' }), null);
+});
+
+test('getCachedLawSummary returns null when the cache entry is missing', () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'law-summary-cache-read-'));
+
+  assert.equal(getCachedLawSummary({ celex: '32016R0679', cacheDir, model: 'test-model' }), null);
+});
 
 test('parseLawSummaryJson keeps only valid article citations', () => {
   const input = buildLawSummaryInput(sampleParsedLaw());


### PR DESCRIPTION
## Summary
- add a public cached-only law summary endpoint
- preserve the versioned summary response contract
- never resolve, parse, generate, or charge a generation allowance
- return a stable 404 when no compatible cached summary exists

## Verification
- node --test backend/shared/law-summary-service.test.js
- node --check backend/routes/api-routes.js
- node --check backend/shared/law-summary-service.js
- git diff --check

The normal route test file remains locally blocked by the repository's missing better-sqlite3 dependency; focused route coverage is included for CI.