### PR TITLE
fix: upgrade adm-zip to 0.6.0 (CVE-2026-39244)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "adm-zip": "^0.6.0",
         "better-sqlite3": "^12.11.1",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -26,7 +27,7 @@
         "node": ">=22.12"
       },
       "optionalDependencies": {
-        "adm-zip": "^0.5.16"
+        "adm-zip": "^0.6.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -626,13 +627,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
-    "adm-zip": "^0.5.16"
+    "adm-zip": "^0.6.0"
   },
   "engines": {
     "node": ">=22.12"


### PR DESCRIPTION
## Summary
Upgrade adm-zip from 0.5.16 to 0.6.0 to fix CVE-2026-39244.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-39244 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-39244` |
| **File** | `backend/package-lock.json` (dependency: `adm-zip`) |
| **Assessment** | Likely exploitable |

**Description**: adm-zip: adm-zip: Denial of Service via crafted ZIP file leading to excessive memory allocation

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-39244` flagged this pattern.

## Changes
- `backend/package.json`
- `backend/package-lock.json`

## Behavior Preservation
This change touches only dependency manifests (`backend/package.json`, `backend/package-lock.json`); no source file in the repository is modified.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=CVE-2026-39244 scanner=trivy vuln=CVE-2026-39244 -->
