### PR TITLE
Add optional passage totals to full-text search

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -274,7 +274,13 @@ Each result contains `{ celex, title, unitType, number, heading, snippet,
 highlightRanges }`; the snippet is plain text and ranges use zero-based
 `{start, end}` offsets. If the optional artifact is missing or stale, the
 endpoint returns `503` with `code=fulltext_index_unavailable` and the
-full-text status details.
+full-text status details. Add `includeCounts=true` (or `1`) to a GET request,
+or `includeCounts: true` to a POST body, to receive exact
+`totalMatchingPassages`, `totalMatchingActs`, and a `matchCount` for every
+returned result; these counts cover all matching indexed units before the
+preview limit. Scoped GET and POST collection responses also include
+`matchCountsByCelex` for every matching act in scope. Unscoped GET omits that
+map to keep global responses bounded.
 
 ## MCP server
 

--- a/backend/search/fulltext-route.js
+++ b/backend/search/fulltext-route.js
@@ -8,6 +8,25 @@ const {
 
 const FULLTEXT_COLLECTION_MAX_CELEXES = 200;
 
+function includesCounts(value) {
+  return value === true || value === 1 || value === "true" || value === "1";
+}
+
+function addCountMetadata(payload, results, metadata, { includeMatchCountsByCelex }) {
+  const matchCountsByCelex = metadata.matchCountsByCelex || {};
+  const countedResults = results.map((result) => ({
+    ...result,
+    matchCount: matchCountsByCelex[result.celex] || 0,
+  }));
+  return {
+    ...payload,
+    totalMatchingPassages: metadata.totalMatchingPassages || 0,
+    totalMatchingActs: metadata.totalMatchingActs || 0,
+    ...(includeMatchCountsByCelex ? { matchCountsByCelex } : {}),
+    results: countedResults,
+  };
+}
+
 function fulltextCelexesRequiredError() {
   return {
     error: 'Request body property "celexes" must be a non-empty array',
@@ -71,12 +90,15 @@ function createFulltextSearchHandler(store, { validateCelex, collection = false 
           limit: input.limit,
           celexes: normalized.celexes,
         });
-        return res.json({
+        const payload = {
           query,
           celexes: normalized.celexes,
           count: results.length,
           results,
-        });
+        };
+        if (!includesCounts(input.includeCounts)) return res.json(payload);
+        const metadata = store.getFulltextMatchCounts(query, { celexes: normalized.celexes });
+        return res.json(addCountMetadata(payload, results, metadata, { includeMatchCountsByCelex: true }));
       }
 
       let celex = null;
@@ -91,7 +113,12 @@ function createFulltextSearchHandler(store, { validateCelex, collection = false 
         limit: input.limit,
         celex,
       });
-      return res.json({ query, celex, count: results.length, results });
+      const payload = { query, celex, count: results.length, results };
+      if (!includesCounts(input.includeCounts)) return res.json(payload);
+      const metadata = store.getFulltextMatchCounts(query, { celex });
+      return res.json(addCountMetadata(payload, results, metadata, {
+        includeMatchCountsByCelex: Boolean(celex),
+      }));
     } catch (error) {
       if (isFulltextIndexUnavailable(error)) {
         return res.status(503).json({

--- a/backend/search/fulltext-route.test.js
+++ b/backend/search/fulltext-route.test.js
@@ -58,6 +58,77 @@ test("fulltext POST route normalizes and deduplicates a CELEX collection", () =>
   }]);
 });
 
+test("fulltext route adds counts only for an explicit opt-in", () => {
+  const calls = [];
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits(query, options) {
+      calls.push({ type: "results", query, options });
+      return [{ celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] }];
+    },
+    getFulltextMatchCounts(query, options) {
+      calls.push({ type: "counts", query, options });
+      return {
+        totalMatchingPassages: 3,
+        totalMatchingActs: 2,
+        matchCountsByCelex: { "32016R0679": 2, "32024R1689": 1 },
+      };
+    },
+  }, {
+    validateCelex: (value) => ["32016R0679", "32024R1689"].includes(value),
+    collection: true,
+  });
+
+  const legacy = response();
+  handler({ method: "POST", body: { q: "data", celexes: ["32016R0679"] } }, legacy);
+  assert.deepEqual(legacy.payload, {
+    query: "data",
+    celexes: ["32016R0679"],
+    count: 1,
+    results: [{ celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] }],
+  });
+  assert.equal(calls.filter((call) => call.type === "counts").length, 0);
+
+  for (const includeCounts of [true, "true", "1", 1]) {
+    const res = response();
+    handler({ method: "POST", body: { q: "data", celexes: ["32016R0679", "32024R1689"], includeCounts } }, res);
+    assert.equal(res.payload.totalMatchingPassages, 3);
+    assert.equal(res.payload.totalMatchingActs, 2);
+    assert.deepEqual(res.payload.matchCountsByCelex, { "32016R0679": 2, "32024R1689": 1 });
+    assert.equal(res.payload.results[0].matchCount, 2);
+  }
+  assert.equal(calls.filter((call) => call.type === "counts").length, 4);
+});
+
+test("unscoped GET omits the global count map while scoped GET includes it", () => {
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits() {
+      return [{ celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] }];
+    },
+    getFulltextMatchCounts(query, { celex }) {
+      assert.equal(query, "data");
+      if (celex) {
+        assert.equal(celex, "32016R0679");
+        return { totalMatchingPassages: 2, totalMatchingActs: 1, matchCountsByCelex: { [celex]: 2 } };
+      }
+      return {
+        totalMatchingPassages: 3,
+        totalMatchingActs: 2,
+        matchCountsByCelex: { "32016R0679": 2, "32024R1689": 1 },
+      };
+    },
+  }, { validateCelex: (value) => value === "32016R0679" });
+
+  const global = response();
+  handler({ query: { q: "data", includeCounts: "true" } }, global);
+  assert.equal(global.payload.matchCountsByCelex, undefined);
+  assert.equal(global.payload.results[0].matchCount, 2);
+
+  const scoped = response();
+  handler({ query: { q: "data", celex: "32016R0679", includeCounts: "1" } }, scoped);
+  assert.deepEqual(scoped.payload.matchCountsByCelex, { "32016R0679": 2 });
+  assert.equal(scoped.payload.totalMatchingPassages, 2);
+});
+
 test("fulltext POST route rejects malformed collections with stable codes", () => {
   const handler = createFulltextSearchHandler({
     searchFulltextUnits() { throw new Error("must not search invalid input"); },

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -593,6 +593,9 @@ class JsonLegalCacheStore {
     this.fulltextUnitScopedSearchStatement = null;
     this.fulltextUnitCollectionSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
+    this.fulltextMatchCountsStatement = null;
+    this.fulltextScopedMatchCountsStatement = null;
+    this.fulltextCollectionMatchCountsStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
     this.fulltextStats = { unitCount: 0, actCount: 0, version: null, generatedAt: null };
@@ -622,6 +625,9 @@ class JsonLegalCacheStore {
     this.fulltextUnitScopedSearchStatement = null;
     this.fulltextUnitCollectionSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
+    this.fulltextMatchCountsStatement = null;
+    this.fulltextScopedMatchCountsStatement = null;
+    this.fulltextCollectionMatchCountsStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
     this.fulltextStats = { unitCount: 0, actCount: 0, version: null, generatedAt: null };
@@ -698,6 +704,34 @@ class JsonLegalCacheStore {
         ORDER BY bestRank, u.id
         LIMIT ${FULLTEXT_UNIT_CANDIDATE_CAP}
       `);
+      // Counts deliberately have no result/candidate cap: they describe every
+      // matching body-text unit in the requested scope, while the search
+      // statements above choose a small ranked preview.
+      this.fulltextMatchCountsStatement = database.prepare(`
+        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        FROM units_fts
+        JOIN units u ON u.id = units_fts.rowid
+        WHERE units_fts.text MATCH ?
+        GROUP BY u.celex
+        ORDER BY u.celex
+      `);
+      this.fulltextScopedMatchCountsStatement = database.prepare(`
+        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        FROM units_fts
+        JOIN units u ON u.id = units_fts.rowid
+        WHERE units_fts.text MATCH ? AND u.celex = ?
+        GROUP BY u.celex
+        ORDER BY u.celex
+      `);
+      this.fulltextCollectionMatchCountsStatement = database.prepare(`
+        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        FROM units_fts
+        JOIN units u ON u.id = units_fts.rowid
+        JOIN json_each(?) AS requested ON requested.value = u.celex
+        WHERE units_fts.text MATCH ?
+        GROUP BY u.celex
+        ORDER BY u.celex
+      `);
       // Computing snippet() for the whole candidate window makes common-prefix
       // queries needlessly expensive. Rank/diversify first, then render only
       // the handful of units that cross the API boundary.
@@ -725,6 +759,9 @@ class JsonLegalCacheStore {
       this.fulltextUnitScopedSearchStatement = null;
       this.fulltextUnitCollectionSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
+      this.fulltextMatchCountsStatement = null;
+      this.fulltextScopedMatchCountsStatement = null;
+      this.fulltextCollectionMatchCountsStatement = null;
       this.fulltextAvailable = false;
       this.fulltextReason = error.message;
     }
@@ -837,6 +874,59 @@ class JsonLegalCacheStore {
       });
     }
     return results;
+  }
+
+  getFulltextMatchCounts(query, options = {}) {
+    this.requireFulltext();
+    const queryError = fulltextQueryError(query);
+    if (queryError) throw queryError;
+    const expression = buildFulltextMatchExpression(query);
+    if (!expression) {
+      return { totalMatchingPassages: 0, totalMatchingActs: 0, matchCountsByCelex: {} };
+    }
+
+    const hasCelex = options.celex !== undefined && options.celex !== null && String(options.celex).trim() !== "";
+    const hasCelexes = Object.prototype.hasOwnProperty.call(options, "celexes")
+      && options.celexes !== undefined
+      && options.celexes !== null;
+    if (hasCelex && hasCelexes) {
+      const error = new Error('Specify either "celex" or "celexes", not both');
+      error.code = "fulltext_scope_ambiguous";
+      throw error;
+    }
+
+    const celex = hasCelex ? normalizeCelexLookupKey(options.celex) : null;
+    let rows;
+    if (hasCelexes) {
+      if (!Array.isArray(options.celexes)) {
+        const error = new Error('"celexes" must be an array');
+        error.code = "fulltext_celexes_required";
+        throw error;
+      }
+      const celexes = [...new Set(options.celexes.map(normalizeCelexLookupKey).filter(Boolean))];
+      rows = celexes.length === 0
+        ? []
+        : this.fulltextCollectionMatchCountsStatement.all(JSON.stringify(celexes), expression);
+    } else {
+      rows = celex
+        ? this.fulltextScopedMatchCountsStatement.all(expression, celex)
+        : this.fulltextMatchCountsStatement.all(expression);
+    }
+
+    const matchCountsByCelex = {};
+    let totalMatchingPassages = 0;
+    for (const row of rows) {
+      const key = normalizeCelexLookupKey(row.celex);
+      const matchCount = Number(row.matchCount) || 0;
+      if (!key || matchCount <= 0) continue;
+      matchCountsByCelex[key] = matchCount;
+      totalMatchingPassages += matchCount;
+    }
+    return {
+      totalMatchingPassages,
+      totalMatchingActs: Object.keys(matchCountsByCelex).length,
+      matchCountsByCelex,
+    };
   }
 
   resetIndexes() {
@@ -1674,6 +1764,9 @@ class JsonLegalCacheStore {
       this.fulltextUnitScopedSearchStatement = null;
       this.fulltextUnitCollectionSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
+      this.fulltextMatchCountsStatement = null;
+      this.fulltextScopedMatchCountsStatement = null;
+      this.fulltextCollectionMatchCountsStatement = null;
       this.fulltextAvailable = false;
       this.fulltextReason = "Full-text index is closed";
     }

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -1128,6 +1128,59 @@ test("collection fulltext search ranks only the requested CELEX values", () => {
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
+test("getFulltextMatchCounts counts every matching unit in the requested scope", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-counts-"));
+  const fulltextPath = path.join(tempDir, "fulltext.sqlite");
+  const firstCelex = "32022R0868";
+  const secondCelex = "32024R1689";
+  buildTestFulltextDb(fulltextPath, {
+    [firstCelex]: [
+      { unit_type: "article", number: "1", text: "countprobe first passage." },
+      { unit_type: "article", number: "2", text: "countprobe second passage." },
+      { unit_type: "recital", number: "3", text: "countprobe third passage." },
+    ],
+    [secondCelex]: [
+      { unit_type: "article", number: "1", text: "countprobe other act." },
+    ],
+  });
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath });
+  assert.equal(store.load(), true);
+
+  // The bounded preview selects one best unit per act, but count metadata must
+  // retain every matching indexed article/recital.
+  assert.equal(store.searchFulltextUnits("countprobe", { limit: 1 }).length, 1);
+  assert.deepEqual(store.getFulltextMatchCounts("countprobe"), {
+    totalMatchingPassages: 4,
+    totalMatchingActs: 2,
+    matchCountsByCelex: { [firstCelex]: 3, [secondCelex]: 1 },
+  });
+  assert.deepEqual(store.getFulltextMatchCounts("countprobe", {
+    celexes: [firstCelex, firstCelex.toLowerCase(), secondCelex],
+  }), {
+    totalMatchingPassages: 4,
+    totalMatchingActs: 2,
+    matchCountsByCelex: { [firstCelex]: 3, [secondCelex]: 1 },
+  });
+  assert.deepEqual(store.getFulltextMatchCounts("countprobe", { celex: firstCelex }), {
+    totalMatchingPassages: 3,
+    totalMatchingActs: 1,
+    matchCountsByCelex: { [firstCelex]: 3 },
+  });
+  assert.deepEqual(store.getFulltextMatchCounts("countprobe", { celexes: [firstCelex] }), {
+    totalMatchingPassages: 3,
+    totalMatchingActs: 1,
+    matchCountsByCelex: { [firstCelex]: 3 },
+  });
+  assert.deepEqual(store.getFulltextMatchCounts("notpresent", { celexes: [firstCelex] }), {
+    totalMatchingPassages: 0,
+    totalMatchingActs: 0,
+    matchCountsByCelex: {},
+  });
+
+  store.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
 test("searchFulltextUnits reports an unavailable artifact with a stable code", () => {
   const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath: path.join(os.tmpdir(), `missing-fulltext-${Date.now()}.sqlite`) });
   assert.equal(store.load(), true);


### PR DESCRIPTION
Collection full-text search returns one best passage per act, so consumers cannot distinguish a one-passage match from a law with many matching articles and recitals. For example, “deep fake” in the AI Act produces one collection preview but three matching passages.

Add optional `includeCounts=true` metadata to GET and POST searches: exact passage and act totals before preview limits, per-result passage counts, and a complete count map for bounded collection or single-act scopes. Default responses, ranking, preview limits and one-result-per-act behaviour remain unchanged. Counts use one additional grouped, parameterised query only when requested; no index rebuild or schema change is needed.

Validation: [CI passed](https://github.com/maastrichtlawtech/legalviz.eu/actions/runs/34247509273), including lint, frontend/backend tests and the production build. Regression tests cover scoped and global totals, duplicate CELEX values, zero matches, preview limits and opt-in response behaviour. Local JavaScript syntax checks and `git diff --check` also pass; local backend test execution was blocked by missing `better-sqlite3`, so no dependencies or lockfiles were changed.
