### PR TITLE
Return two previews and article/recital counts for collection search

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -251,7 +251,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/by-reference?actType=...&year=...&number=...` | Fetch law by official reference |
 | `GET` | `/api/search?q=keyword&limit=10` | Search law metadata |
 | `GET` | `/api/fulltext-search?q=keyword&celex=32016R0679&limit=10` | Strict AND search inside English body text (articles and recitals), with snippets and highlight ranges |
-| `POST` | `/api/fulltext-search` with `{ "q": "keyword", "celexes": ["32016R0679"], "limit": 10 }` | Strict AND search inside a supplied CELEX collection |
+| `POST` | `/api/fulltext-search` with `{ "q": "keyword", "celexes": ["32016R0679"], "limit": 10, "previewsPerAct": 2 }` | Strict AND search inside a supplied CELEX collection |
 | `GET` | `/api/definitions/search?q=term&limit=10&filter=different` | Search extracted legal definitions; omit `q` and use `filter=different` or `filter=reused` for discovery |
 | `GET` | `/api/definitions/compare?term=risk` | Compare a term's definitions across laws |
 | `GET` | `/api/topics?celex=32016R0679,32024R1689` | Bulk EuroVoc topics for up to 200 CELEX ids (`{ topics: { CELEX: string[] } }`) |
@@ -268,19 +268,26 @@ terms are prefix-matched and quoted segments are phrase-matched. Queries use
 strict AND semantics and punctuation-only input is rejected. Global results
 return at most one best unit per CELEX; GET requests scoped to one CELEX may
 include multiple matching units from that act. POST requests take
-`{ q, celexes, limit }`, require 1–200 valid CELEX values, and return one best
-unit per requested CELEX after normalising and deduplicating the collection.
+`{ q, celexes, limit, previewsPerAct }`, require 1–200 valid CELEX values, and
+return one best unit per requested CELEX after normalising and deduplicating the
+collection. `previewsPerAct` is a POST collection option, is optional, and
+must be the integer `1` or `2`; it defaults to `1`. With `2`, `limit` still
+bounds matching acts (not result units), and the response returns up to two
+FTS-ranked units for each selected act, ordered by each act's best match and
+then by the unit's rank.
 Each result contains `{ celex, title, unitType, number, heading, snippet,
 highlightRanges }`; the snippet is plain text and ranges use zero-based
 `{start, end}` offsets. If the optional artifact is missing or stale, the
 endpoint returns `503` with `code=fulltext_index_unavailable` and the
 full-text status details. Add `includeCounts=true` (or `1`) to a GET request,
 or `includeCounts: true` to a POST body, to receive exact
-`totalMatchingPassages`, `totalMatchingActs`, and a `matchCount` for every
-returned result; these counts cover all matching indexed units before the
-preview limit. Scoped GET and POST collection responses also include
-`matchCountsByCelex` for every matching act in scope. Unscoped GET omits that
-map to keep global responses bounded.
+`totalMatchingPassages`, `totalMatchingActs`, `totalMatchingArticles`,
+`totalMatchingRecitals`, and a `matchCount` plus
+`matchTypes: { articles, recitals }` for every returned result; these counts
+cover all matching indexed units before the preview limit. Scoped GET and POST
+collection responses also include `matchCountsByCelex` and
+`matchTypesByCelex` (each value is `{ articles, recitals }`) for every matching
+act in scope. Unscoped GET omits those maps to keep global responses bounded.
 
 ## MCP server
 

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -1262,14 +1262,14 @@ test("POST /api/fulltext-search is registered with the shared rate limiter and d
 
   assert.equal(typeof handler, "function");
   assert.deepEqual(app.middleware.get(routeKey), [rateLimitMiddleware]);
-  handler({ method: "POST", body: { q: " data ", celexes: ["32016r0679", "32024R1689", "32016R0679"], limit: 2 } }, res);
+  handler({ method: "POST", body: { q: " data ", celexes: ["32016r0679", "32024R1689", "32016R0679"], limit: 2, previewsPerAct: 2 } }, res);
 
   assert.equal(res.statusCode, 200);
   assert.deepEqual(res.payload.celexes, ["32016R0679", "32024R1689"]);
   assert.equal(res.payload.count, 1);
   assert.deepEqual(calls, [{
     query: "data",
-    options: { limit: 2, celexes: ["32016R0679", "32024R1689"] },
+    options: { limit: 2, celexes: ["32016R0679", "32024R1689"], previewsPerAct: 2 },
   }]);
 });
 

--- a/backend/search/fulltext-route.js
+++ b/backend/search/fulltext-route.js
@@ -7,6 +7,7 @@ const {
 } = require("./fulltext-errors");
 
 const FULLTEXT_COLLECTION_MAX_CELEXES = 200;
+const FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT = 2;
 
 function includesCounts(value) {
   return value === true || value === 1 || value === "true" || value === "1";
@@ -14,15 +15,19 @@ function includesCounts(value) {
 
 function addCountMetadata(payload, results, metadata, { includeMatchCountsByCelex }) {
   const matchCountsByCelex = metadata.matchCountsByCelex || {};
+  const matchTypesByCelex = metadata.matchTypesByCelex || {};
   const countedResults = results.map((result) => ({
     ...result,
     matchCount: matchCountsByCelex[result.celex] || 0,
+    matchTypes: matchTypesByCelex[result.celex] || { articles: 0, recitals: 0 },
   }));
   return {
     ...payload,
     totalMatchingPassages: metadata.totalMatchingPassages || 0,
     totalMatchingActs: metadata.totalMatchingActs || 0,
-    ...(includeMatchCountsByCelex ? { matchCountsByCelex } : {}),
+    totalMatchingArticles: metadata.totalMatchingArticles || 0,
+    totalMatchingRecitals: metadata.totalMatchingRecitals || 0,
+    ...(includeMatchCountsByCelex ? { matchCountsByCelex, matchTypesByCelex } : {}),
     results: countedResults,
   };
 }
@@ -32,6 +37,21 @@ function fulltextCelexesRequiredError() {
     error: 'Request body property "celexes" must be a non-empty array',
     code: "fulltext_celexes_required",
   };
+}
+
+function fulltextPreviewsPerActInvalidError() {
+  return {
+    error: `Request body property "previewsPerAct" must be an integer from 1 to ${FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT}`,
+    code: "fulltext_previews_per_act_invalid",
+  };
+}
+
+function normalizeCollectionPreviewsPerAct(value) {
+  if (value === undefined) return { previewsPerAct: 1 };
+  if (!Number.isInteger(value) || value < 1 || value > FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT) {
+    return { error: fulltextPreviewsPerActInvalidError() };
+  }
+  return { previewsPerAct: value };
 }
 
 function normalizeCollectionCelexes(value, validateCelex) {
@@ -85,10 +105,13 @@ function createFulltextSearchHandler(store, { validateCelex, collection = false 
       if (isCollectionSearch) {
         const normalized = normalizeCollectionCelexes(input.celexes, validateCelex);
         if (normalized.error) return res.status(400).json(normalized.error);
+        const previews = normalizeCollectionPreviewsPerAct(input.previewsPerAct);
+        if (previews.error) return res.status(400).json(previews.error);
 
         const results = store.searchFulltextUnits(query, {
           limit: input.limit,
           celexes: normalized.celexes,
+          ...(previews.previewsPerAct === 1 ? {} : { previewsPerAct: previews.previewsPerAct }),
         });
         const payload = {
           query,

--- a/backend/search/fulltext-route.test.js
+++ b/backend/search/fulltext-route.test.js
@@ -58,6 +58,35 @@ test("fulltext POST route normalizes and deduplicates a CELEX collection", () =>
   }]);
 });
 
+test("fulltext POST route opts into two previews per selected act", () => {
+  const calls = [];
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits(query, options) {
+      calls.push({ query, options });
+      return [
+        { celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] },
+        { celex: "32016R0679", title: "GDPR", unitType: "article", number: "6", snippet: "data", highlightRanges: [] },
+      ];
+    },
+  }, {
+    validateCelex: (value) => value === "32016R0679",
+    collection: true,
+  });
+  const res = response();
+
+  handler({
+    method: "POST",
+    body: { q: "data", celexes: ["32016R0679"], limit: 1, previewsPerAct: 2 },
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.count, 2);
+  assert.deepEqual(calls, [{
+    query: "data",
+    options: { limit: 1, celexes: ["32016R0679"], previewsPerAct: 2 },
+  }]);
+});
+
 test("fulltext route adds counts only for an explicit opt-in", () => {
   const calls = [];
   const handler = createFulltextSearchHandler({
@@ -70,7 +99,13 @@ test("fulltext route adds counts only for an explicit opt-in", () => {
       return {
         totalMatchingPassages: 3,
         totalMatchingActs: 2,
+        totalMatchingArticles: 2,
+        totalMatchingRecitals: 1,
         matchCountsByCelex: { "32016R0679": 2, "32024R1689": 1 },
+        matchTypesByCelex: {
+          "32016R0679": { articles: 2, recitals: 0 },
+          "32024R1689": { articles: 0, recitals: 1 },
+        },
       };
     },
   }, {
@@ -93,10 +128,59 @@ test("fulltext route adds counts only for an explicit opt-in", () => {
     handler({ method: "POST", body: { q: "data", celexes: ["32016R0679", "32024R1689"], includeCounts } }, res);
     assert.equal(res.payload.totalMatchingPassages, 3);
     assert.equal(res.payload.totalMatchingActs, 2);
+    assert.equal(res.payload.totalMatchingArticles, 2);
+    assert.equal(res.payload.totalMatchingRecitals, 1);
     assert.deepEqual(res.payload.matchCountsByCelex, { "32016R0679": 2, "32024R1689": 1 });
+    assert.deepEqual(res.payload.matchTypesByCelex, {
+      "32016R0679": { articles: 2, recitals: 0 },
+      "32024R1689": { articles: 0, recitals: 1 },
+    });
     assert.equal(res.payload.results[0].matchCount, 2);
+    assert.deepEqual(res.payload.results[0].matchTypes, { articles: 2, recitals: 0 });
   }
   assert.equal(calls.filter((call) => call.type === "counts").length, 4);
+});
+
+test("fulltext POST two previews retain exact count metadata for each result", () => {
+  const handler = createFulltextSearchHandler({
+    searchFulltextUnits() {
+      return [
+        { celex: "32016R0679", title: "GDPR", unitType: "article", number: "5", snippet: "data", highlightRanges: [] },
+        { celex: "32016R0679", title: "GDPR", unitType: "article", number: "6", snippet: "data", highlightRanges: [] },
+      ];
+    },
+    getFulltextMatchCounts() {
+      return {
+        totalMatchingPassages: 3,
+        totalMatchingActs: 1,
+        totalMatchingArticles: 2,
+        totalMatchingRecitals: 1,
+        matchCountsByCelex: { "32016R0679": 3 },
+        matchTypesByCelex: { "32016R0679": { articles: 2, recitals: 1 } },
+      };
+    },
+  }, {
+    validateCelex: (value) => value === "32016R0679",
+    collection: true,
+  });
+  const res = response();
+
+  handler({
+    method: "POST",
+    body: { q: "data", celexes: ["32016R0679"], previewsPerAct: 2, includeCounts: true },
+  }, res);
+
+  assert.equal(res.payload.totalMatchingPassages, 3);
+  assert.equal(res.payload.totalMatchingActs, 1);
+  assert.equal(res.payload.totalMatchingArticles, 2);
+  assert.equal(res.payload.totalMatchingRecitals, 1);
+  assert.deepEqual(res.payload.matchCountsByCelex, { "32016R0679": 3 });
+  assert.deepEqual(res.payload.matchTypesByCelex, { "32016R0679": { articles: 2, recitals: 1 } });
+  assert.deepEqual(res.payload.results.map((result) => result.matchCount), [3, 3]);
+  assert.deepEqual(res.payload.results.map((result) => result.matchTypes), [
+    { articles: 2, recitals: 1 },
+    { articles: 2, recitals: 1 },
+  ]);
 });
 
 test("unscoped GET omits the global count map while scoped GET includes it", () => {
@@ -108,12 +192,25 @@ test("unscoped GET omits the global count map while scoped GET includes it", () 
       assert.equal(query, "data");
       if (celex) {
         assert.equal(celex, "32016R0679");
-        return { totalMatchingPassages: 2, totalMatchingActs: 1, matchCountsByCelex: { [celex]: 2 } };
+        return {
+          totalMatchingPassages: 2,
+          totalMatchingActs: 1,
+          totalMatchingArticles: 1,
+          totalMatchingRecitals: 1,
+          matchCountsByCelex: { [celex]: 2 },
+          matchTypesByCelex: { [celex]: { articles: 1, recitals: 1 } },
+        };
       }
       return {
         totalMatchingPassages: 3,
         totalMatchingActs: 2,
+        totalMatchingArticles: 2,
+        totalMatchingRecitals: 1,
         matchCountsByCelex: { "32016R0679": 2, "32024R1689": 1 },
+        matchTypesByCelex: {
+          "32016R0679": { articles: 1, recitals: 1 },
+          "32024R1689": { articles: 1, recitals: 0 },
+        },
       };
     },
   }, { validateCelex: (value) => value === "32016R0679" });
@@ -121,11 +218,14 @@ test("unscoped GET omits the global count map while scoped GET includes it", () 
   const global = response();
   handler({ query: { q: "data", includeCounts: "true" } }, global);
   assert.equal(global.payload.matchCountsByCelex, undefined);
+  assert.equal(global.payload.matchTypesByCelex, undefined);
   assert.equal(global.payload.results[0].matchCount, 2);
+  assert.deepEqual(global.payload.results[0].matchTypes, { articles: 1, recitals: 1 });
 
   const scoped = response();
   handler({ query: { q: "data", celex: "32016R0679", includeCounts: "1" } }, scoped);
   assert.deepEqual(scoped.payload.matchCountsByCelex, { "32016R0679": 2 });
+  assert.deepEqual(scoped.payload.matchTypesByCelex, { "32016R0679": { articles: 1, recitals: 1 } });
   assert.equal(scoped.payload.totalMatchingPassages, 2);
 });
 
@@ -154,6 +254,14 @@ test("fulltext POST route rejects malformed collections with stable codes", () =
     handler({ method: "POST", body: { q: "data", celexes } }, res);
     assert.equal(res.statusCode, 400);
     assert.equal(res.payload.code, "invalid_celex");
+  }
+
+  for (const previewsPerAct of [0, 3, 1.5, "2", null, {}]) {
+    const res = response();
+    handler({ method: "POST", body: { q: "data", celexes: ["32016R0679"], previewsPerAct } }, res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.payload.code, "fulltext_previews_per_act_invalid");
+    assert.equal(res.payload.error, 'Request body property "previewsPerAct" must be an integer from 1 to 2');
   }
 });
 

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -163,6 +163,8 @@ const FULLTEXT_QUERY_MAX_CHARS = 200;
 const FULLTEXT_MAX_TERMS = 12;
 const FULLTEXT_MIN_STANDALONE_TERM_CHARS = 2;
 const FULLTEXT_RESULT_LIMIT = 50;
+const FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT = 2;
+const FULLTEXT_COLLECTION_RESULT_LIMIT = FULLTEXT_RESULT_LIMIT * FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT;
 // Public full-text search deliberately scans a bounded, bm25-ordered window.
 // 500 units is large enough to diversify common terms across acts while
 // keeping short-prefix queries from walking the entire 382k-unit index.
@@ -592,6 +594,7 @@ class JsonLegalCacheStore {
     this.fulltextUnitSearchStatement = null;
     this.fulltextUnitScopedSearchStatement = null;
     this.fulltextUnitCollectionSearchStatement = null;
+    this.fulltextUnitCollectionTwoPreviewsSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
     this.fulltextMatchCountsStatement = null;
     this.fulltextScopedMatchCountsStatement = null;
@@ -624,6 +627,7 @@ class JsonLegalCacheStore {
     this.fulltextUnitSearchStatement = null;
     this.fulltextUnitScopedSearchStatement = null;
     this.fulltextUnitCollectionSearchStatement = null;
+    this.fulltextUnitCollectionTwoPreviewsSearchStatement = null;
     this.fulltextUnitSnippetStatement = null;
     this.fulltextMatchCountsStatement = null;
     this.fulltextScopedMatchCountsStatement = null;
@@ -704,38 +708,63 @@ class JsonLegalCacheStore {
         ORDER BY bestRank, u.id
         LIMIT ${FULLTEXT_UNIT_CANDIDATE_CAP}
       `);
+      this.fulltextUnitCollectionTwoPreviewsSearchStatement = database.prepare(`
+        WITH matched AS (
+          SELECT u.id AS id, u.celex AS celex, u.unit_type AS unitType,
+                 u.number AS number, u.heading AS heading,
+                 units_fts.rank AS unitRank,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY u.celex
+                   ORDER BY units_fts.rank, u.id
+                 ) AS previewRank,
+                 MIN(units_fts.rank) OVER (PARTITION BY u.celex) AS bestActRank,
+                 FIRST_VALUE(u.id) OVER (
+                   PARTITION BY u.celex
+                   ORDER BY units_fts.rank, u.id
+                 ) AS firstActId
+          FROM units_fts
+          JOIN units u ON u.id = units_fts.rowid
+          JOIN json_each(?) AS requested ON requested.value = u.celex
+          WHERE units_fts.text MATCH ?
+        )
+        SELECT id, celex, unitType, number, heading, unitRank, previewRank, bestActRank, firstActId
+        FROM matched
+        WHERE previewRank <= ${FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT}
+        ORDER BY bestActRank, firstActId, previewRank, unitRank, id
+        LIMIT ${FULLTEXT_UNIT_CANDIDATE_CAP}
+      `);
       // Counts deliberately have no result/candidate cap: they describe every
       // matching body-text unit in the requested scope, while the search
       // statements above choose a small ranked preview.
       this.fulltextMatchCountsStatement = database.prepare(`
-        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        SELECT u.celex AS celex, u.unit_type AS unitType, COUNT(*) AS matchCount
         FROM units_fts
         JOIN units u ON u.id = units_fts.rowid
         WHERE units_fts.text MATCH ?
-        GROUP BY u.celex
-        ORDER BY u.celex
+        GROUP BY u.celex, u.unit_type
+        ORDER BY u.celex, u.unit_type
       `);
       this.fulltextScopedMatchCountsStatement = database.prepare(`
-        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        SELECT u.celex AS celex, u.unit_type AS unitType, COUNT(*) AS matchCount
         FROM units_fts
         JOIN units u ON u.id = units_fts.rowid
         WHERE units_fts.text MATCH ? AND u.celex = ?
-        GROUP BY u.celex
-        ORDER BY u.celex
+        GROUP BY u.celex, u.unit_type
+        ORDER BY u.celex, u.unit_type
       `);
       this.fulltextCollectionMatchCountsStatement = database.prepare(`
-        SELECT u.celex AS celex, COUNT(*) AS matchCount
+        SELECT u.celex AS celex, u.unit_type AS unitType, COUNT(*) AS matchCount
         FROM units_fts
         JOIN units u ON u.id = units_fts.rowid
         JOIN json_each(?) AS requested ON requested.value = u.celex
         WHERE units_fts.text MATCH ?
-        GROUP BY u.celex
-        ORDER BY u.celex
+        GROUP BY u.celex, u.unit_type
+        ORDER BY u.celex, u.unit_type
       `);
       // Computing snippet() for the whole candidate window makes common-prefix
       // queries needlessly expensive. Rank/diversify first, then render only
       // the handful of units that cross the API boundary.
-      const resultSlots = Array(FULLTEXT_RESULT_LIMIT).fill("?").join(", ");
+      const resultSlots = Array(FULLTEXT_COLLECTION_RESULT_LIMIT).fill("?").join(", ");
       this.fulltextUnitSnippetStatement = database.prepare(`
         SELECT units_fts.rowid AS id, ${snippet} AS snippet
         FROM units_fts
@@ -758,6 +787,7 @@ class JsonLegalCacheStore {
       this.fulltextUnitSearchStatement = null;
       this.fulltextUnitScopedSearchStatement = null;
       this.fulltextUnitCollectionSearchStatement = null;
+      this.fulltextUnitCollectionTwoPreviewsSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
       this.fulltextMatchCountsStatement = null;
       this.fulltextScopedMatchCountsStatement = null;
@@ -817,6 +847,16 @@ class JsonLegalCacheStore {
     const hasCelexes = Object.prototype.hasOwnProperty.call(options, "celexes")
       && options.celexes !== undefined
       && options.celexes !== null;
+    const previewsPerAct = options.previewsPerAct === undefined ? 1 : options.previewsPerAct;
+    if (!Number.isInteger(previewsPerAct)
+      || previewsPerAct < 1
+      || previewsPerAct > FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT) {
+      const error = new Error(
+        `"previewsPerAct" must be an integer from 1 to ${FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT}`
+      );
+      error.code = "fulltext_previews_per_act_invalid";
+      throw error;
+    }
     if (hasCelex && hasCelexes) {
       const error = new Error('Specify either "celex" or "celexes", not both');
       error.code = "fulltext_scope_ambiguous";
@@ -834,7 +874,9 @@ class JsonLegalCacheStore {
       const celexes = [...new Set(options.celexes.map(normalizeCelexLookupKey).filter(Boolean))];
       rows = celexes.length === 0
         ? []
-        : this.fulltextUnitCollectionSearchStatement.all(JSON.stringify(celexes), expression);
+        : previewsPerAct === FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT
+          ? this.fulltextUnitCollectionTwoPreviewsSearchStatement.all(JSON.stringify(celexes), expression)
+          : this.fulltextUnitCollectionSearchStatement.all(JSON.stringify(celexes), expression);
     } else {
       rows = celex
         ? this.fulltextUnitScopedSearchStatement.all(expression, celex)
@@ -843,17 +885,19 @@ class JsonLegalCacheStore {
     const seen = new Set();
     const selected = [];
     for (const row of rows) {
-      // Global and collection searches return one best unit per act. A
-      // single-CELEX query intentionally keeps multiple provisions from that
-      // requested act.
-      if (!celex && seen.has(row.celex)) continue;
+      // Global and legacy collection searches return one best unit per act. A
+      // two-preview collection retains up to two ranked units from each of its
+      // selected acts; a single-CELEX query keeps multiple provisions.
+      const collectionPreviews = hasCelexes && previewsPerAct === FULLTEXT_COLLECTION_MAX_PREVIEWS_PER_ACT;
+      if (!celex && !collectionPreviews && seen.has(row.celex)) continue;
+      if (!seen.has(row.celex) && seen.size >= limit) break;
       seen.add(row.celex);
       selected.push(row);
-      if (selected.length >= limit) break;
+      if (!collectionPreviews && selected.length >= limit) break;
     }
     if (selected.length === 0) return [];
     const snippetArgs = selected.map((row) => row.id);
-    while (snippetArgs.length < FULLTEXT_RESULT_LIMIT) snippetArgs.push(-1);
+    while (snippetArgs.length < FULLTEXT_COLLECTION_RESULT_LIMIT) snippetArgs.push(-1);
     const snippets = new Map(
       this.fulltextUnitSnippetStatement.all(...snippetArgs, expression)
         .map((row) => [Number(row.id), row.snippet])
@@ -882,7 +926,14 @@ class JsonLegalCacheStore {
     if (queryError) throw queryError;
     const expression = buildFulltextMatchExpression(query);
     if (!expression) {
-      return { totalMatchingPassages: 0, totalMatchingActs: 0, matchCountsByCelex: {} };
+      return {
+        totalMatchingPassages: 0,
+        totalMatchingActs: 0,
+        totalMatchingArticles: 0,
+        totalMatchingRecitals: 0,
+        matchCountsByCelex: {},
+        matchTypesByCelex: {},
+      };
     }
 
     const hasCelex = options.celex !== undefined && options.celex !== null && String(options.celex).trim() !== "";
@@ -914,18 +965,40 @@ class JsonLegalCacheStore {
     }
 
     const matchCountsByCelex = {};
+    const matchTypesByCelex = {};
     let totalMatchingPassages = 0;
+    let totalMatchingArticles = 0;
+    let totalMatchingRecitals = 0;
     for (const row of rows) {
       const key = normalizeCelexLookupKey(row.celex);
       const matchCount = Number(row.matchCount) || 0;
       if (!key || matchCount <= 0) continue;
-      matchCountsByCelex[key] = matchCount;
+      matchCountsByCelex[key] = (matchCountsByCelex[key] || 0) + matchCount;
+      const matchTypes = matchTypesByCelex[key] || { articles: 0, recitals: 0 };
+      matchTypesByCelex[key] = matchTypes;
+      switch (String(row.unitType || "").toLowerCase()) {
+        case "article":
+          matchTypes.articles += matchCount;
+          totalMatchingArticles += matchCount;
+          break;
+        case "recital":
+          matchTypes.recitals += matchCount;
+          totalMatchingRecitals += matchCount;
+          break;
+        default:
+          // Preserve the all-unit passage count for a future indexed unit
+          // type without falsely assigning it to articles or recitals.
+          break;
+      }
       totalMatchingPassages += matchCount;
     }
     return {
       totalMatchingPassages,
       totalMatchingActs: Object.keys(matchCountsByCelex).length,
+      totalMatchingArticles,
+      totalMatchingRecitals,
       matchCountsByCelex,
+      matchTypesByCelex,
     };
   }
 
@@ -1763,6 +1836,7 @@ class JsonLegalCacheStore {
       this.fulltextUnitSearchStatement = null;
       this.fulltextUnitScopedSearchStatement = null;
       this.fulltextUnitCollectionSearchStatement = null;
+      this.fulltextUnitCollectionTwoPreviewsSearchStatement = null;
       this.fulltextUnitSnippetStatement = null;
       this.fulltextMatchCountsStatement = null;
       this.fulltextScopedMatchCountsStatement = null;

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -1128,6 +1128,48 @@ test("collection fulltext search ranks only the requested CELEX values", () => {
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
+test("collection fulltext search can return two ranked previews per selected act", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-collection-two-previews-"));
+  const fulltextPath = path.join(tempDir, "fulltext.sqlite");
+  const strongerCelex = "32024R1689";
+  const singlePreviewCelex = "32016R0679";
+  buildTestFulltextDb(fulltextPath, {
+    [strongerCelex]: [
+      { unit_type: "article", number: "1", text: `${"twopreviewprobe ".repeat(20)}first ranked provision.` },
+      { unit_type: "article", number: "2", text: `${"twopreviewprobe ".repeat(10)}second ranked provision.` },
+      { unit_type: "article", number: "3", text: "twopreviewprobe third provision." },
+    ],
+    [singlePreviewCelex]: [
+      { unit_type: "recital", number: "4", text: "twopreviewprobe only provision." },
+    ],
+  });
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath });
+  assert.equal(store.load(), true);
+
+  const results = store.searchFulltextUnits("twopreviewprobe", {
+    limit: 2,
+    celexes: [strongerCelex, singlePreviewCelex],
+    previewsPerAct: 2,
+  });
+  assert.deepEqual(results.map((result) => result.celex), [strongerCelex, strongerCelex, singlePreviewCelex]);
+  assert.deepEqual(results.slice(0, 2).map((result) => result.number), ["1", "2"]);
+  assert.equal(new Set(results.map((result) => `${result.celex}:${result.unitType}:${result.number}`)).size, results.length);
+
+  const oneAct = store.searchFulltextUnits("twopreviewprobe", {
+    limit: 1,
+    celexes: [strongerCelex, singlePreviewCelex],
+    previewsPerAct: 2,
+  });
+  assert.deepEqual(oneAct.map((result) => result.celex), [strongerCelex, strongerCelex]);
+  assert.throws(
+    () => store.searchFulltextUnits("twopreviewprobe", { celexes: [strongerCelex], previewsPerAct: 3 }),
+    (error) => error.code === "fulltext_previews_per_act_invalid",
+  );
+
+  store.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
 test("getFulltextMatchCounts counts every matching unit in the requested scope", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-counts-"));
   const fulltextPath = path.join(tempDir, "fulltext.sqlite");
@@ -1152,29 +1194,86 @@ test("getFulltextMatchCounts counts every matching unit in the requested scope",
   assert.deepEqual(store.getFulltextMatchCounts("countprobe"), {
     totalMatchingPassages: 4,
     totalMatchingActs: 2,
+    totalMatchingArticles: 3,
+    totalMatchingRecitals: 1,
     matchCountsByCelex: { [firstCelex]: 3, [secondCelex]: 1 },
+    matchTypesByCelex: {
+      [firstCelex]: { articles: 2, recitals: 1 },
+      [secondCelex]: { articles: 1, recitals: 0 },
+    },
   });
   assert.deepEqual(store.getFulltextMatchCounts("countprobe", {
     celexes: [firstCelex, firstCelex.toLowerCase(), secondCelex],
   }), {
     totalMatchingPassages: 4,
     totalMatchingActs: 2,
+    totalMatchingArticles: 3,
+    totalMatchingRecitals: 1,
     matchCountsByCelex: { [firstCelex]: 3, [secondCelex]: 1 },
+    matchTypesByCelex: {
+      [firstCelex]: { articles: 2, recitals: 1 },
+      [secondCelex]: { articles: 1, recitals: 0 },
+    },
+  });
+  assert.deepEqual(store.getFulltextMatchCounts("countprobe", {
+    celexes: [firstCelex, secondCelex],
+  }), {
+    totalMatchingPassages: 4,
+    totalMatchingActs: 2,
+    totalMatchingArticles: 3,
+    totalMatchingRecitals: 1,
+    matchCountsByCelex: { [firstCelex]: 3, [secondCelex]: 1 },
+    matchTypesByCelex: {
+      [firstCelex]: { articles: 2, recitals: 1 },
+      [secondCelex]: { articles: 1, recitals: 0 },
+    },
   });
   assert.deepEqual(store.getFulltextMatchCounts("countprobe", { celex: firstCelex }), {
     totalMatchingPassages: 3,
     totalMatchingActs: 1,
+    totalMatchingArticles: 2,
+    totalMatchingRecitals: 1,
     matchCountsByCelex: { [firstCelex]: 3 },
+    matchTypesByCelex: { [firstCelex]: { articles: 2, recitals: 1 } },
   });
   assert.deepEqual(store.getFulltextMatchCounts("countprobe", { celexes: [firstCelex] }), {
     totalMatchingPassages: 3,
     totalMatchingActs: 1,
+    totalMatchingArticles: 2,
+    totalMatchingRecitals: 1,
     matchCountsByCelex: { [firstCelex]: 3 },
+    matchTypesByCelex: { [firstCelex]: { articles: 2, recitals: 1 } },
   });
   assert.deepEqual(store.getFulltextMatchCounts("notpresent", { celexes: [firstCelex] }), {
     totalMatchingPassages: 0,
     totalMatchingActs: 0,
+    totalMatchingArticles: 0,
+    totalMatchingRecitals: 0,
     matchCountsByCelex: {},
+    matchTypesByCelex: {},
+  });
+
+  store.close();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("getFulltextMatchCounts preserves future unit types without mislabelling them", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-fulltext-unknown-count-type-"));
+  const fulltextPath = path.join(tempDir, "fulltext.sqlite");
+  const celex = "32016R0679";
+  buildTestFulltextDb(fulltextPath, {
+    [celex]: [{ unit_type: "annex", number: "I", text: "unknowncounttypeprobe annex wording." }],
+  });
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true, fulltextPath });
+  assert.equal(store.load(), true);
+
+  assert.deepEqual(store.getFulltextMatchCounts("unknowncounttypeprobe", { celex }), {
+    totalMatchingPassages: 1,
+    totalMatchingActs: 1,
+    totalMatchingArticles: 0,
+    totalMatchingRecitals: 0,
+    matchCountsByCelex: { [celex]: 1 },
+    matchTypesByCelex: { [celex]: { articles: 0, recitals: 0 } },
   });
 
   store.close();


### PR DESCRIPTION
Collection full-text search currently returns one excerpt per act and exposes only a combined unit count. This adds an opt-in `previewsPerAct: 2` mode, while keeping `limit` as the maximum number of matching acts, and reports matching article and recital counts both globally and per CELEX.

The default response remains unchanged unless callers request the new preview option or existing `includeCounts` metadata. Preview selection uses one bounded SQLite window query, and count metadata remains uncapped.

Validation:
- `node --check backend/search/fulltext-route.js`
- `node --check backend/search/legal-cache-store.js`
- `git diff --check`

The focused Node tests could not run locally because this isolated worktree has no installed backend dependencies (`Cannot find module 'better-sqlite3'`); CI should exercise the added route and SQLite store coverage.
